### PR TITLE
Fix Strict-Transport-Security response header not set

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -107,7 +107,7 @@ frontend https
     http-request add-header X-Forwarded-Proto https
     http-request set-header X-Forwarded-Host %[req.hdr(Host)]
     http-request add-header X-Forwarded-Port %[dst_port]
-    http-request add-header Strict-Transport-Security max-age=15768000
+    http-response add-header Strict-Transport-Security max-age=15768000
 
     # Gateway tunnelling config
     .if defined(SISH_HOST) && defined(SISH_PORT)


### PR DESCRIPTION
See: https://www.haproxy.com/blog/haproxy-and-http-strict-transport-security-hsts#configure-the-strict-transport-security-header