### PR TITLE
Pin GitHub Action versions using commit SHAs

### DIFF
--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: styfle/cancel-workflow-action@0.8.0
+      - uses: styfle/cancel-workflow-action@3d86a7cc43670094ac248017207be0295edbc31d # 0.8.0
         with:
           access_token: ${{ github.token }}
       
@@ -41,16 +41,16 @@ jobs:
         env:
           TAG: ${{ github.event.release.tag_name }}
           
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       
       - name: set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1
         with:
           platforms: all
       
       - name: install buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1
         with:
           version: latest
           install: true
@@ -59,7 +59,7 @@ jobs:
         run: echo ${{ steps.buildx.outputs.platforms }}
         
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
         with:
           username: ${{ secrets._TEMP_DOCKERHUB_USER }}
           password: ${{ secrets._TEMP_DOCKERHUB_PASSWORD }}


### PR DESCRIPTION
The tags can be changed by bad actors causing supply chain security issues such as CVE-2025-30066. GitHub is still working on immutable actions (https://github.com/github/roadmap/issues/592) which is a solution to this problem.