### PR TITLE
Configure concurrency to cancel "In progress" actions

### DIFF
--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -17,6 +17,10 @@ on:
     paths-ignore:
       - '**/*.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   image_proxy:
@@ -27,10 +31,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
-        with:
-          access_token: ${{ github.token }}
-
       - name: Set tags
         run: |
           if [ -z "$TAG" ]; then


### PR DESCRIPTION
The styfle/cancel-workflow-action is no longer necessary to accomplish this nowadays.

See: https://github.com/styfle/cancel-workflow-action