### PR TITLE
Add GZip compression to HAProxy config file

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -145,7 +145,6 @@ listen mqtt
 backend manager_backend
   compression algo gzip deflate # Enable compression
   compression type text/html text/css application/javascript application/json image/svg+xml
-  compression minsize-res 1500
   compression offload
   server manager "${MANAGER_HOST}":"${MANAGER_WEB_PORT}" resolvers docker_resolver
   .if defined(MANAGER_PATH_PREFIX)


### PR DESCRIPTION
## Description
Fixes #13 

As a simple test, I tried out this HAProxy config locally to experiment if the Manager UI would load properly.
I'm not an expert in HAProxy nor any proxy application, so it was just a simple attempt 😉 
I looked at the [official documentation](https://www.haproxy.com/documentation/haproxy-configuration-tutorials/performance/compression/), and made adjustments based on that.

It seems to correctly apply the GZip compression, and significantly reduce the download sizes.
For example, the Manager UI bundle went down from 6.5MB to about 2.7MB.

Any feedback on this is welcome 👍 

## Changelog
- Adds GZip compression to HTML, CSS, JavaScript, JSON, and SVG files from the Manager backend.