### PR TITLE
Move back to the LTS 2.8 version for more recent updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # HAProxy image with certbot for certificate generation and renewal
 #
 # -----------------------------------------------------------------------------------------------
-FROM haproxy:2.9-alpine
+FROM haproxy:2.8-alpine
 LABEL maintainer="support@openremote.io"
 
 USER root


### PR DESCRIPTION
The current 2.9 release is not an LTS version and hasn't been updated for quite some time. Switch to 2.8 LTS for recent bug and security fixes